### PR TITLE
Added additional SetValue methods to TextureBatchItem using a Matrix3…

### DIFF
--- a/TrippyGL/TextureBatchItem.cs
+++ b/TrippyGL/TextureBatchItem.cs
@@ -183,6 +183,41 @@ namespace TrippyGL
         }
 
         /// <summary>
+        /// Calculates and sets all the values in this <see cref="TextureBatchItem"/> except for <see cref="SortValue"/>.
+        /// </summary>
+        public void SetValue(Texture2D texture, Matrix3x2 transform, Rectangle source, Color4b color, Vector2 origin, float depth)
+        {
+            transform.Translation -= Vector2.TransformNormal(origin, transform);
+
+            SetValue(texture,transform,source,color, depth);
+        }
+
+        /// <summary>
+        /// Calculates and sets all the values in this <see cref="TextureBatchItem"/> except for <see cref="SortValue"/>.
+        /// </summary>
+        public void SetValue(Texture2D texture, Matrix3x2 transform, Rectangle source, Color4b color, float depth)
+        {
+            Texture = texture;            
+
+            transform = Matrix3x2.CreateScale(source.Width, source.Height) * transform;
+            
+            VertexTL.Position = new Vector3(transform.Translation, depth);
+            VertexTR.Position = new Vector3(transform.M11 + transform.M31, transform.M12 + transform.M32, depth);
+            VertexBL.Position = new Vector3(transform.M21 + transform.M31, transform.M22 + transform.M32, depth);
+            VertexBR.Position = new Vector3(transform.M11 + transform.M21 + transform.M31, transform.M12 + transform.M22 + transform.M32, depth);            
+
+            VertexTL.TexCoords = new Vector2(source.X / (float)texture.Width, source.Y / (float)texture.Height);
+            VertexBR.TexCoords = new Vector2(source.Right / (float)texture.Width, source.Bottom / (float)texture.Height);
+            VertexTR.TexCoords = new Vector2(VertexBR.TexCoords.X, VertexTL.TexCoords.Y);
+            VertexBL.TexCoords = new Vector2(VertexTL.TexCoords.X, VertexBR.TexCoords.Y);
+
+            VertexTL.Color = color;
+            VertexTR.Color = color;
+            VertexBL.Color = color;
+            VertexBR.Color = color;
+        }
+
+        /// <summary>
         /// Compares this item's <see cref="SortValue"/> with another item's.
         /// </summary>
         public int CompareTo(TextureBatchItem? other)

--- a/TrippyGL/TextureBatcher.cs
+++ b/TrippyGL/TextureBatcher.cs
@@ -339,6 +339,43 @@ namespace TrippyGL
         /// Adds a <see cref="Texture2D"/> for drawing to the current batch.
         /// </summary>
         /// <param name="texture">The <see cref="Texture2D"/> to draw.</param>
+        /// <param name="transform">The location (Scale*Rotation*Translation) at which to draw the texture.</param>
+        /// <param name="source">The area of the texture to draw (or null to draw the whole texture).</param>
+        /// <param name="color">The color with which to draw the texture.</param>        
+        /// <param name="depth">The depth at which to draw the texture.</param>
+        public void Draw(Texture2D texture, in Matrix3x2 transform, Rectangle? source, Color4b color, float depth = 0)
+        {
+            StartDraw(texture);
+
+            TextureBatchItem item = GetNextBatchItem();
+            item.SetValue(texture, transform, source ?? new Rectangle(0, 0, (int)texture.Width, (int)texture.Height), color, depth);
+
+            EndDraw(item);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="Texture2D"/> for drawing to the current batch.
+        /// </summary>
+        /// <param name="texture">The <see cref="Texture2D"/> to draw.</param>
+        /// <param name="transform">The location (Scale*Rotation*Translation) at which to draw the texture.</param>
+        /// <param name="source">The area of the texture to draw (or null to draw the whole texture).</param>
+        /// <param name="color">The color with which to draw the texture.</param>
+        /// <param name="origin">The origin for rotation and scaling in pixel coordinates.</param>
+        /// <param name="depth">The depth at which to draw the texture.</param>
+        public void Draw(Texture2D texture, in Matrix3x2 transform, Rectangle? source, Color4b color, Vector2 origin, float depth = 0)
+        {
+            StartDraw(texture);
+
+            TextureBatchItem item = GetNextBatchItem();
+            item.SetValue(texture, transform, source ?? new Rectangle(0, 0, (int)texture.Width, (int)texture.Height), color, origin, depth);
+
+            EndDraw(item);
+        }
+
+        /// <summary>
+        /// Adds a <see cref="Texture2D"/> for drawing to the current batch.
+        /// </summary>
+        /// <param name="texture">The <see cref="Texture2D"/> to draw.</param>
         /// <param name="position">The position at which to draw the texture.</param>
         /// <param name="source">The area of the texture to draw (or null to draw the whole texture).</param>
         /// <param name="color">The color with which to draw the texture.</param>

--- a/TrippyTests/TextureBatcherTest/TextureBatcherTest.cs
+++ b/TrippyTests/TextureBatcherTest/TextureBatcherTest.cs
@@ -115,7 +115,7 @@ namespace TextureBatcherTest
             graphicsDevice.Clear(ClearBuffers.Color);
 
             Vector2 mousePos = new Vector2(InputContext.Mice[0].Position.X, InputContext.Mice[0].Position.Y);
-
+            
             textureBatcher.Begin(BatcherBeginMode.OnTheFly);
 
             float loreIpsumScale = 1 + 0.1f * MathF.Sin(time * 4.32f);
@@ -137,6 +137,17 @@ namespace TextureBatcherTest
 
             textureBatcher.End();
 
+            // example of drawing textures using a matrix for bone concatenation:
+            textureBatcher.Begin(BatcherBeginMode.OnTheFly);
+            var diamondCorner = new Vector2(35, 0);
+            var xform0 = Matrix3x2.CreateScale(1.5f) * Matrix3x2.CreateTranslation(300, 200);
+            var xform1 = Matrix3x2.CreateRotation(time) * Matrix3x2.CreateTranslation(0, 60);            
+            textureBatcher.Draw(diamondTexture, xform1 * xform0, null, Color4b.White, diamondCorner);
+            textureBatcher.Draw(diamondTexture, xform1 * xform1 * xform0, null, Color4b.White, diamondCorner);
+            textureBatcher.Draw(diamondTexture, xform1 * xform1 * xform1 * xform0, null, Color4b.White, diamondCorner);
+            textureBatcher.Draw(diamondTexture, xform1 * xform1 * xform1 * xform1 * xform0, null, Color4b.White, diamondCorner);
+            textureBatcher.Draw(diamondTexture, xform1 * xform1 * xform1 * xform1 * xform1 * xform0, null, Color4b.White, diamondCorner);
+            textureBatcher.End();
 
             textureBatcher.Begin(BatcherBeginMode.SortBackToFront);
             Vector2 rectOrigin = new Vector2(rectangleTexture.Width / 2f, rectangleTexture.Height / 2f);


### PR DESCRIPTION
Added additional SetValue methods to TextureBatchItem using a Matrix3x2 transform generalization.

This allows transform concatenations in scenarios like complex graphics animations, skewing, and viewport size virtualization, which are not possible with any of the other "SetValue" methods.